### PR TITLE
Bug fix for empty .rep file

### DIFF
--- a/R2admb/R/read-funs.r
+++ b/R2admb/R/read-funs.r
@@ -33,7 +33,7 @@
 ##'@export read_pars
 
 read_pars <- function (fn,drop_phase=TRUE) {
-    ## seeN
+    ## see
     ##  http://admb-project.org/community/admb-meeting-march-29-31/InterfacingADMBwithR.pdf
     ## for an alternate file reader -- does this have equivalent functionality?
     ## FIXME: get hessian.bin ?


### PR DESCRIPTION
`read_pars0()` would return an error if a .rep file existed, but was empty (by virtue of having an empty REPORT_SECTION in the .tpl file, for example). This is a quick one liner to ensure `read_rep()` is only called when the .rep file is not empty.
