### PR TITLE
Bug fix for a PARAMETER_SECTION only containing LOCAL_CALCS or comments.

### DIFF
--- a/R2admb/R/read-funs.r
+++ b/R2admb/R/read-funs.r
@@ -298,18 +298,20 @@ read_tpl <- function(f) {
     if (!is.null(pp)) {
         pp <- proc_var(pp,maxlen=7)
         type <- 1 ## kluge for R CMD check warnings; will be masked
-        L1 <- with(pp,
-                   list(inits=pp[grep("^init",type),],
-                        raneff=pp[grep("^random",type),],
-                        sdnums=pp[grep("^sdreport_number",type),],
-                        sdvecs=pp[grep("^sdreport_vector",type),],
-                        other=pp[grep("^init|random|sdreport",type,invert=TRUE),],
-                        ## FIXME: don't know what I needed this for
-                        ## sdvecdims <- gsub("^ +sdreport_vector[ a-zA-Z]+","",
-                        ## gsub("[()]","",
-                        ## grep( "^ +sdreport_vector",splsec$PARAMETER,
-                        ## value=TRUE)))
-                        profparms=pp[grep("^likeprof",type),]))
+        if (!is.null(pp)) {
+            L1 <- with(pp,
+                       list(inits=pp[grep("^init",type),],
+                            raneff=pp[grep("^random",type),],
+                            sdnums=pp[grep("^sdreport_number",type),],
+                            sdvecs=pp[grep("^sdreport_vector",type),],
+                            other=pp[grep("^init|random|sdreport",type,invert=TRUE),],
+                            ## FIXME: don't know what I needed this for
+                            ## sdvecdims <- gsub("^ +sdreport_vector[ a-zA-Z]+","",
+                            ## gsub("[()]","",
+                            ## grep( "^ +sdreport_vector",splsec$PARAMETER,
+                            ## value=TRUE)))
+                            profparms=pp[grep("^likeprof",type),]))
+        }
     }
     pp <- splsec_proc$DATA
     if (!is.null(pp)) {

--- a/R2admb/R/utility-funs.R
+++ b/R2admb/R/utility-funs.R
@@ -197,15 +197,18 @@ proc_var <- function(s,drop.first=TRUE,maxlen) {
   rest <- sapply(words,"[[",2)
   rest2 <- strsplit(gsub("[(),]"," ",rest)," ")
   vname <- sapply(rest2,"[[",1)
-  maxlen0 <- max(sapply(rest2,length))
-  if (missing(maxlen)) maxlen <- maxlen0
-  else maxlen <- pmax(maxlen,maxlen0)
-  opts <- t(sapply(rest2,
-           function(w) {
-             ## as.numeric()?
-             c(w[-1],rep(NA,maxlen+1-length(w)))
-           }))
-  data.frame(type,vname,opts,stringsAsFactors=FALSE)
+  if (length(rest2) == 0) ret <- NULL else {
+    maxlen0 <- max(sapply(rest2,length))
+    if (missing(maxlen)) maxlen <- maxlen0
+    else maxlen <- pmax(maxlen,maxlen0)
+    opts <- t(sapply(rest2,
+                     function(w) {
+                       ## as.numeric()?
+                       c(w[-1],rep(NA,maxlen+1-length(w)))
+                     }))
+    ret <- data.frame(type,vname,opts,stringsAsFactors=FALSE)
+  }
+  ret
 }
 
 drop_calcs <- function(s) {


### PR DESCRIPTION
If the PARAMETER_SECTION passed to `do_admb()` only contains LOCAL_CALCS or comments, then `proc_var()` strips all lines within it away. This causes an error when

```
maxlen0 <- max(sapply(rest2,length))
```

is called, as `rest2` is an empty list.

This was important for me as I wanted to implement parameter scaling, and (as far as I know) the only way to do this is with LOCAL_CALCS inside the PARAMETER_SECTION.

The fix is a little messy but seems to work. Perhaps there is a neater way of doing this.
