### PR TITLE
try default location in for the ADMB .dmg in MacOS

### DIFF
--- a/R2admb/R/setup_admb.R
+++ b/R2admb/R/setup_admb.R
@@ -59,6 +59,9 @@ setup_admb <- function(admb_home) {
                 } else if (file.exists("/usr/local/admb")) {
                     ## try default location
                     admb_home <- "/usr/local/admb"
+                } else if (file.exists("/Applications/ADMBTerminal.app/admb/admb")) {
+                    ## try default location for MacOSx application
+                    admb_home <- "/Applications/ADMBTerminal.app/admb"
                 } else {
                     admb_home <- ""
                 }


### PR DESCRIPTION
The ADMB people has compiled a MacOS application for ADMB. After installation the default folder for `admb` is `/Applications/ADMBTerminal.app/admb`. Adding that option should make things a bit easier for those who, like me, are using R2admb in mac. :)