### PR TITLE
Potential fix for having a PRELIMINARY_CALCS_SECTION before PROCEDURE…

### DIFF
--- a/R2admb/R/do_admb.r
+++ b/R2admb/R/do_admb.r
@@ -214,7 +214,7 @@ do_admb <- function(fn,
             } else {
                 ## insert immediately before PROCEDURE
                 tpldat$secs <- append(tpldat$secs,list(PARAMETER=c(dmsg,"")),
-                                      after=which(names(tpldat$secs)=="PROCEDURE")-1)
+                                      after=which.min(names(tpldat$secs) %in% c("PRELIMINARY","PROCEDURE"))-1)
             }
             ## modifications to PROCEDURE section:
             ## need to assign MCMC reporting variables


### PR DESCRIPTION
…_SECTION

The following code does not work without this fix. The issue is that the old code puts the PRELIMINARY_CALCS_SECTION before the DATA_SECTION and the PARAMETER_SECTION.

```
library(R2admb)
setup_admb("/usr/local/admb")
src <- "
PRELIMINARY_CALCS_SECTION
  X.rowshift(0);
  X.colshift(0);
PROCEDURE_SECTION
  --beta;
  --y;
  dvar_vector mu = exp(X * beta);
  for (int i=y.indexmin(); i<=y.indexmax(); ++i)
    f -= log_density_poisson(y[i], mu[i]);
  ++beta;
  ++y;
"
write(src, file="test.tpl")
## test data
set.seed(12345)
n <- 1e3
X <- cbind(1, rep(c(0,1),n/2),rnorm(n))
y <- rpois(n, exp(X %*% c(-3,1,1)))
dat <- list(y=y, X=X)
undebug(do_admb)
do_admb("test",
        data=dat,
        params=list(beta=c(-5,0,0)),
        verbose=TRUE,
        run.opts=run.control(clean=FALSE, checkdata="write", checkparam="write"))

```